### PR TITLE
Fix sed regex for cygwin build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ bdsync.txt.2: bdsync.txt
 ifndef OS
 	sed 's/\(.*\)/"\1\\n"/g' bdsync.txt > bdsync.txt.2
 else
-	sed 's/\(.*\)\r/"\1\\r\\n"/g' bdsync.txt > bdsync.txt.2
+	sed 's/\(.*\)/"\1\\r\\n"/g' bdsync.txt > bdsync.txt.2
 endif
 
 bdsync: bdsync.c checkzero.c bdsync.txt.2


### PR DESCRIPTION
The search filter wouldn't hit with the \r in it and dot doesn't match line breaks, so we don't need to select it in the first place.