### PR TITLE
Required packages to compile on Windows

### DIFF
--- a/COMPILING
+++ b/COMPILING
@@ -34,7 +34,7 @@ Windows (using cygwin)
 
 # install cygwin for Windows
 https://cygwin.com/install.html
-# Select packages gcc-g++, make, openssl-devel, wget, unzip on the 'Select Packages' screen
+# Select packages gcc-g++, make, libssl-devel, wget, unzip on the 'Select Packages' screen
 # Install Pandoc
 https://pandoc.org/installing.html
 # Add pandoc to the path


### PR DESCRIPTION
It seems the package name openssl-devel was changed to libssl-devel in cygwin. For reference see:
https://stackoverflow.com/questions/64950324/unable-to-locate-package-openssl-dev
