### PR TITLE
bdsync.txt should always be checked out with unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+bdsync.txt	text eol=lf
+

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,7 @@ CFLAGS=-O3
 all: bdsync bdsync.1
 
 bdsync.txt.2: bdsync.txt
-ifndef OS
 	sed 's/\(.*\)/"\1\\n"/g' bdsync.txt > bdsync.txt.2
-else
-	sed 's/\(.*\)/"\1\\r\\n"/g' bdsync.txt > bdsync.txt.2
-endif
 
 bdsync: bdsync.c checkzero.c bdsync.txt.2
 	$(CC) -Wall $(CFLAGS) $(CRYPTO_DEF) -o bdsync bdsync.c checkzero.c $(CRYPTO_LDFLAGS)


### PR DESCRIPTION
Figured it out. 
Commit "[Fix sed regex for cygwin build](https://github.com/rolffokkens/bdsync/pull/33/commits/fd4817805b49ada74322c12b3366c5dbf3dc60b1)" was indeed needed, as sed regex is greedy.

Another problem occurs however when cloning is done on Windows; all texts files will be set to "dos" format with \r\n line ending.. making compilation to fail.
Last time I copied the source for Linux to Windows.. so it worked fine.
After some reading it is possible to ask git to always check out a given file with unix line endings; making compilation consistent. [How to change line ending settings](https://stackoverflow.com/questions/10418975/how-to-change-line-ending-settings)
